### PR TITLE
Fix ivy specification of artifacts to match the definiton in sbt.

### DIFF
--- a/project/SbtRepublish.scala
+++ b/project/SbtRepublish.scala
@@ -80,7 +80,9 @@ object SbtRepublish extends Build {
     "compiler-interface",
     file("compiler-interface"),
     settings = buildSettings ++ Seq(
-      libraryDependencies <+= originalSbtVersion { "org.scala-sbt" % "compiler-interface" % _ % Deps.name classifier "src" },
+      libraryDependencies <+= originalSbtVersion { v =>
+        ("org.scala-sbt" % "compiler-interface" % v % Deps.name).artifacts(Artifact("compiler-interface-src"))
+      },
       packageSrc in Compile <<= repackageDependency(packageSrc, "compiler-interface-src"),
       publishArtifact in packageBin := false,
       publishArtifact in (Compile, packageSrc) := true


### PR DESCRIPTION
Fix to explicitly specify artifacts _and_ ensure that the "bin" artifact is not used by "src" and vice versa.  Note: This fixes the issue where dbuild can't line up artifacts between sbt + sbt-republish correctly.

Review by @pvlugter 
